### PR TITLE
add progression to the songs + prologue song

### DIFF
--- a/Config/SpringCollab2020/rando.yaml
+++ b/Config/SpringCollab2020/rando.yaml
@@ -92,7 +92,32 @@ Music:
 - Name: "event:/SC2020_Rue_Beginner"
 - Name: "event:/SC2020_skeleton_beginner"
 - Name: "event:/SC2020_TG90BEG"
+# Beginner Heartside and all progression levels
+# No 0 progress, it is super repetitive and I would never want to hear that in a song over and over
 - Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 1
+- Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 2
+- Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 3
+- Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 4
+- Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 5
+- Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 6
+- Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 7
+- Name: "event:/collab2020/heartside_beginner"
+  Parameters:
+    heartside_beginner_progress: 8
 # Intermediate maps
 - Name: "event:/SC2020_aleph_int"
 - Name: "event:/SC2020_aridai_int"
@@ -118,6 +143,7 @@ Music:
 - Name: "event:/SC2020_Cookie_adv"
 - Name: "event:/Dozing_Collab"
 - Name: "event:/SC2020_GALAXYZ_ADV"
+# The Climb has weird progression settings theres like 20 different parameters and I had to look in Ahorn
 - Name: "event:/collab2020/holly"
 - Name: "event:/SC2020_Dadbod_Adv"
 - Name: "event:/SC2020_Linj_Adv"
@@ -141,7 +167,36 @@ Music:
 - Name: "event:/SC2020_Radley"
 - Name: "event:/SC2020_Thejank90_Expert"
 - Name: "event:/collab2020/zerex"
+# Expert heartside and all its progression levels
+# 0 is weighted at 0.5 due to repetitivity
 - Name: "event:/collab2020/heartside_expert"
+  Weight: 0.5
+  Parameters:
+    exh_progress: 0
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 1
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 2
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 3
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 4
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 5
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 6
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 7
+- Name: "event:/collab2020/heartside_expert"
+  Parameters:
+    exh_progress: 8
 # Grandmaster maps
 - Name: "event:/SC2020_Bissy_Heck_KevinII"
 - Name: "event:/SC2020_BobDole_Dustforce"

--- a/Config/SpringCollab2020/rando.yaml
+++ b/Config/SpringCollab2020/rando.yaml
@@ -74,8 +74,12 @@ CollectableNames:
 - "SpringCollab2020/diagonalWingedStrawberry"
   
 Music:
+# Prologue
+# has 3 extra layers
+- Name: "event:/collab2020/lobbytest
 # Lobbies
 # Beginner lobby has progression I just couldn't figure it out
+# also has 3 extra layers
 - Name: "event:/collab2020/beginner_lobby"
 - Name: "event:/SC2020_Int_Lobby"
 # Not 100% sure on these progressions but it sounds correct to me
@@ -99,6 +103,7 @@ Music:
     layer3: 1
     layer4: 1
 # Same as beginner lobby
+# also has 3 extra layers
 - Name: "event:/collab2020/expert_lobby"
 - Name: "event:/SC2020_Lobby_Grandmaster"
   Parameters: 
@@ -120,6 +125,7 @@ Music:
     speedlayer4: 280
 # Beginner maps
 - Name: "event:/SC2020_Jude"
+# 3 layers
 - Name: "event:/collab2020/bissy_beginner"
 - Name: "event:/SC2020_canadian_int"
 - Name: "event:/SC2020_Cruor"
@@ -132,6 +138,7 @@ Music:
 - Name: "event:/SC2020_TG90BEG"
 # Beginner Heartside and all progression levels
 # No 0 progress, it is super repetitive and I would never want to hear that in a song over and over
+# also has 3 extra layers
 - Name: "event:/collab2020/heartside_beginner"
   Parameters:
     heartside_beginner_progress: 1
@@ -161,11 +168,13 @@ Music:
 - Name: "event:/SC2020_aridai_int"
 - Name: "event:/SC2020_Bissy_Intermed"
 - Name: "event:/SC2020_Hyper"
+# 3 layers
 - Name: "event:/collab2020/donker"
 - Name: "event:/SC2020_EvilLeafy"
 - Name: "event:/SC2020_Goat_Collab"
 - Name: "event:/SC2020_Collab_Lichtbaulb_Intermediate-3.5"
 - Name: "event:/SC2020_Noax"
+# 3 layers
 - Name: "event:/collab2020/oppen"
 - Name: "event:/music/phant_collab"
 - Name: "event:/SC2020_Rocketguy_collab"
@@ -176,6 +185,7 @@ Music:
 - Name: "event:/SC2020_Int_Heartside"
 # Advanced maps
 - Name: "event:/SC2020_Collab_Sleepie_Advanced-4"
+# 3 layers
 - Name: "event:/collab2020/beefy"
 - Name: "event:/SC2020_Collab_Bissy_Advanced-3"
 - Name: "event:/SC2020_Cookie_adv"
@@ -183,6 +193,7 @@ Music:
 - Name: "event:/SC2020_GALAXYZ_ADV"
 # Couldn't quite figure out how this song worked even in Ahorn, so I'm just leaving it to four simple progressions
 # There are probably like 10 not included on this 
+# also has 3 extra layers 
 - Name: "event:/collab2020/holly"
   Parameters:
     hlayer1: 1
@@ -204,6 +215,7 @@ Music:
 - Name: "event:/SC2020_Dadbod_Adv"
 - Name: "event:/SC2020_Linj_Adv"
 - Name: "event:/SC2020_NeoKat_Nyoom"
+# 3 layers
 - Name: "event:/collab2020/percussive"
 - Name: "event:/SC2020_Rufus"
 - Name: "event:/SC2020_Spoopy"
@@ -220,17 +232,21 @@ Music:
 # Expert maps
 - Name: "event:/SC2020_Bissy_Expert"
 - Name: "event:/SC2020_Canadian_Expert"
+# 3 layers
 - Name: "event:/collab2020/chaotic"
 - Name: "event:/SC2020_Deskilln_Collab"
 - Name: "event:/SC2020_Dadbod_Octo"
 - Name: "event:/SC2020_Kube_Collab"
 - Name: "event:/SC2020_LethargicDoggo"
+# 3 layers
 - Name: "event:/collab2020/mun"
 - Name: "event:/SC2020_Radley"
 - Name: "event:/SC2020_Thejank90_Expert"
+# 3 layers
 - Name: "event:/collab2020/zerex"
 # Expert Heartside and all its progression levels
 # 0 is weighted at 0.5 due to repetitivity
+# also has 3 extra layers
 - Name: "event:/collab2020/heartside_expert"
   Weight: 0.5
   Parameters:
@@ -262,6 +278,7 @@ Music:
 # Grandmaster maps
 - Name: "event:/SC2020_Bissy_Heck_KevinII"
 - Name: "event:/SC2020_BobDole_Dustforce"
+# 3 layers
 - Name: "event:/collab2020/canadian"
 - Name: "event:/SC2020_Cyber_Heck_Music"
 - Name: "event:/SC2020_WoofWoofDoggo"

--- a/Config/SpringCollab2020/rando.yaml
+++ b/Config/SpringCollab2020/rando.yaml
@@ -75,11 +75,49 @@ CollectableNames:
   
 Music:
 # Lobbies
+# Beginner lobby has progression I just couldn't figure it out
 - Name: "event:/collab2020/beginner_lobby"
 - Name: "event:/SC2020_Int_Lobby"
+# Not 100% sure on these progressions but it sounds correct to me
+# Checking in Ahorn would only give me more confusion
 - Name: "event:/SC2020_Lobby_advanced"
+  Parameters:
+    layer1: 1
+- Name: "event:/SC2020_Lobby_advanced"
+  Parameters:
+    layer1: 1
+    layer2: 1
+- Name: "event:/SC2020_Lobby_advanced"
+  Parameters:
+    layer1: 1
+    layer2: 1
+    layer3: 1
+- Name: "event:/SC2020_Lobby_advanced"
+  Parameters:
+    layer1: 1
+    layer2: 1
+    layer3: 1
+    layer4: 1
+# Same as beginner lobby
 - Name: "event:/collab2020/expert_lobby"
 - Name: "event:/SC2020_Lobby_Grandmaster"
+  Parameters: 
+    layer1: 1
+- Name: "event:/SC2020_Lobby_Grandmaster"
+  Parameters: 
+    layer1: 1
+    layer2: 1
+- Name: "event:/SC2020_Lobby_Grandmaster"
+  Parameters: 
+    layer1: 1
+    layer2: 1
+    speedlayer3: 89
+- Name: "event:/SC2020_Lobby_Grandmaster"
+  Parameters: 
+    layer1: 1
+    layer2: 1
+    speedlayer3: 89
+    speedlayer4: 280
 # Beginner maps
 - Name: "event:/SC2020_Jude"
 - Name: "event:/collab2020/bissy_beginner"
@@ -143,8 +181,26 @@ Music:
 - Name: "event:/SC2020_Cookie_adv"
 - Name: "event:/Dozing_Collab"
 - Name: "event:/SC2020_GALAXYZ_ADV"
-# The Climb has weird progression settings theres like 20 different parameters and I had to look in Ahorn
+# Couldn't quite figure out how this song worked even in Ahorn, so I'm just leaving it to four simple progressions
+# There are probably like 10 not included on this 
 - Name: "event:/collab2020/holly"
+  Parameters:
+    hlayer1: 1
+- Name: "event:/collab2020/holly"
+  Parameters:
+    hlayer1: 1
+    hlayer2: 1
+- Name: "event:/collab2020/holly"
+  Parameters:
+    hlayer1: 1
+    hlayer2: 1
+    hlayer3: 1
+- Name: "event:/collab2020/holly"
+  Parameters:
+    hlayer1: 1
+    hlayer2: 1
+    hlayer3: 1
+    hlayer4: 1
 - Name: "event:/SC2020_Dadbod_Adv"
 - Name: "event:/SC2020_Linj_Adv"
 - Name: "event:/SC2020_NeoKat_Nyoom"
@@ -154,6 +210,12 @@ Music:
 - Name: "event:/taco360_Collab"
 - Name: "event:/SC2020_Thegur90_Advanced"
 - Name: "event:/SC2020_Tortoise"
+  Parameters:
+    layer1: 1
+- Name: "event:/SC2020_Tortoise"
+  Parameters:
+    layer1: 1
+    layer2: 1
 - Name: "event:/SC2020_Tortoise_Boss"
 # Expert maps
 - Name: "event:/SC2020_Bissy_Expert"
@@ -167,7 +229,7 @@ Music:
 - Name: "event:/SC2020_Radley"
 - Name: "event:/SC2020_Thejank90_Expert"
 - Name: "event:/collab2020/zerex"
-# Expert heartside and all its progression levels
+# Expert Heartside and all its progression levels
 # 0 is weighted at 0.5 due to repetitivity
 - Name: "event:/collab2020/heartside_expert"
   Weight: 0.5


### PR DESCRIPTION
not fully completed due to a number of reasons, but it should work fine
first, its not entirely obvious what some progressions are even when looking in Ahorn, so the only ones i filled out were ones that were obvious
second, noticed a bunch of songs with layers that started turned up all the way. it sounds like the layering may get turned down in the level, may want to check these
events to check are beginner lobby, advanced lobby, expert lobby, and the climb, as well as any other songs that have multiple layers that are turned on by default (which have notes above them)

despite all this it should work completely fine as is